### PR TITLE
Log inserts, updates and csv size_bytes

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -221,15 +221,15 @@ def flush_records(stream, records_to_load, row_count, db_sync, temp_dir=None):
         temp_dir = os.path.expanduser(temp_dir)
         os.makedirs(temp_dir, exist_ok=True)
 
+    size_bytes = 0
     csv_fd, csv_file = mkstemp(suffix='.csv', prefix=f'{stream}_', dir=temp_dir)
     with open(csv_fd, 'w+b') as f:
         for record in records_to_load.values():
             csv_line = db_sync.record_to_csv_line(record)
             f.write(bytes(csv_line + '\n', 'UTF-8'))
 
-        # Seek to the beginning of the file and load
-        f.seek(0)
-        db_sync.load_csv(f, row_count)
+    size_bytes = os.path.getsize(csv_file)
+    db_sync.load_csv(csv_file, row_count, size_bytes)
 
     # Delete temp file
     os.remove(csv_file)


### PR DESCRIPTION
Postgres equivalent of the PR https://github.com/transferwise/pipelinewise-target-snowflake/pull/69 and https://github.com/transferwise/pipelinewise-target-redshift/pull/52

For better logging experience adding the csv file size to the logs and logging load stats in a more consumable JSON format:

```
time=2020-05-01 01:51:03 name=target_postgres level=INFO message=Loading into test_pk."test_table_one": {"inserts": 0, "updates": 1, "size_bytes": 8}
time=2020-05-01 01:51:03 name=target_postgres level=INFO message=Loading into test_pk."test_table_one": {"inserts": 1, "updates": 0, "size_bytes": 8}
time=2020-05-01 01:51:03 name=target_postgres level=INFO message=Loading into test_pk."test_table_two": {"inserts": 2, "updates": 0, "size_bytes": 60}
time=2020-05-01 01:51:03 name=target_postgres level=INFO message=Loading into test_pk."test_table_three": {"inserts": 3, "updates": 0, "size_bytes": 57}
time=2020-05-01 01:51:03 name=target_postgres level=INFO message=Loading into test_pk."test_table_four": {"inserts": 3, "updates": 0, "size_bytes": 30}
```