### PR TITLE
Make pylint happy

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -298,7 +298,7 @@ class DbSync:
             self.connection_config['password'],
             self.connection_config['port']
         )
-        
+
         if 'ssl' in self.connection_config and self.connection_config['ssl'] == 'true':
             conn_string += " sslmode='require'"
 


### PR DESCRIPTION
CircleCI is currently failing with a pylint error:

```
$ pylint --rcfile .pylintrc --disable duplicate-code target_postgres/
************* Module target_postgres.db_sync
target_postgres/db_sync.py:301: [C0303(trailing-whitespace), ] Trailing whitespace

------------------------------------------------------------------
Your code has been rated at 9.98/10 (previous run: 9.16/10, +0.82)
```

This PR is removing a whitespace.