### PR TITLE
[AP-806] Bump joblib to be python 3.8 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name="pipelinewise-target-postgres",
           'pipelinewise-singer-python==1.*',
           'psycopg2-binary==2.8.5',
           'inflection==0.3.1',
-          'joblib==0.13.2'
+          'joblib==0.16.0'
       ],
       extras_require={
           "test": [


### PR DESCRIPTION
## Problem

PPW is currently failing on python 3.8. More info at https://github.com/transferwise/pipelinewise-target-snowflake/pull/99

## Proposed changes

Bump the failing `joblib` to 0.16.0 

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
