### PR TITLE
ignore null keys parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@ setup(name="pipelinewise-target-postgres",
       py_modules=["target_postgres"],
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'psycopg2-binary==2.8.5',
+          'psycopg2-binary==2.*',
           'inflection==0.3.1',
+          "pydevd-pycharm~=212.5284.44",
           'joblib==0.16.0'
       ],
       extras_require={


### PR DESCRIPTION
## Problem

sometimes tap sends null primary keys, you want to keep primary keys just ignore the null rows

## Proposed changes

ignore_null_key parameter
also added the pycharm scafolding to debug from orchestration system which you can delete if its not interesting

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions