### PR TITLE
Correctly recognize tables when the incoming schema name is not all l…

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -518,7 +518,7 @@ class DbSync:
     def get_tables(self):
         return self.query(
             'SELECT table_name FROM information_schema.tables WHERE table_schema = %s',
-            (self.schema_name,)
+            (self.schema_name.lower(),)
         )
 
     def get_table_columns(self, table_name):


### PR DESCRIPTION
## Problem

The schema name used to look up tables in PG is the value coming in from the stream which may be mixed case.

## Proposed changes

Lower cases the schema name before retrieving the table list from PG so it matches the name created during the initial import. Fixes #70 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions