### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
 
     steps:
       - name: Checkout repository

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name="pipelinewise-target-postgres",
       ],
       extras_require={
           "test": [
-              'pytest==6.2.1',
+              'pytest==6.2.5',
               'pylint==2.6.0',
               'pytest-cov==2.10.1',
           ]

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -2,12 +2,12 @@ import json
 import sys
 import psycopg2
 import psycopg2.extras
-import collections
 import inflection
 import re
 import uuid
 import itertools
 import time
+from collections.abc import MutableMapping
 from singer import get_logger
 
 
@@ -147,7 +147,7 @@ def flatten_record(d, flatten_schema=None, parent_key=[], sep='__', level=0, max
     items = []
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
-        if isinstance(v, collections.MutableMapping) and level < max_level:
+        if isinstance(v, MutableMapping) and level < max_level:
             items.extend(flatten_record(v, flatten_schema, parent_key + [k], sep=sep, level=level + 1,
                                         max_level=max_level).items())
         else:


### PR DESCRIPTION
## Problem

This PR resolves an import issue #92 that prevents running on Python 3.10. Issues with testing under Python 3.10 are also resolved.

## Proposed changes

The changes made to support Python 3.10 are:
- updating pytest to 6.2.5 resolve test running issues on Python 3.10, while maintaining compatibility with Python 3.6,
- inclusion of Python 3.9 and 3.10 in the CI tests,
- changing the module that MutableMapping is imported from, as the old location was deprecated in Python 3.3 and no longer works in Python 3.10, to resolve #92.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions