### PR TITLE
v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.1.2 (2023-01-17)
+-------------------
+- Add python 3.10 compatibility
+- Bump `joblib` from 0.16.0 to 1.2.0
+- Bump `psychopg2-binary` from 2.8.5 to 2.9.5 to get macOS arm64 (Apple M1) wheels
+
 2.1.1 (2021-05-11)
 -------------------
 - Bump `joblib` from 0.13.2 to 0.16.0 to be Python 3.8 compatible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 -------------------
 - Add python 3.10 compatibility
 - Bump `joblib` from 0.16.0 to 1.2.0
-- Bump `psychopg2-binary` from 2.8.5 to 2.9.5 to get macOS arm64 (Apple M1) wheels
+- Bump `psycopg2-binary` from 2.8.5 to 2.9.5 to get macOS arm64 (Apple M1) wheels
 
 2.1.1 (2021-05-11)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name="pipelinewise-target-postgres",
-      version="2.1.1",
+      version="2.1.2",
       description="Singer.io target for loading data to PostgreSQL - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
## Problem

The latest `2.1.1` version of this connector on PyPI doesn't run on apple m1 processors, because the compatible `psycopg2-binary` wheels added at [psycopg2-3.9.3](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-9-3). Psycopg has already been bumped in the main branch by https://github.com/transferwise/pipelinewise-target-postgres/pull/106 but the new build has not been released to PyPI: https://pypi.org/project/pipelinewise-target-postgres/

## Proposed changes

Bump version of this connector from `2.1.1` to `2.1.2` so the new release will be built with the apple m1 compatible `psycopg-binary` and will be published to PyPI.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions