### PR TITLE
Fix csv quoting mechanism to preserve line feeds

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -181,6 +181,10 @@ def stream_name_to_dict(stream_name, separator='-'):
     }
 
 
+def csv_quote(s):
+    return '"' + str(s).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
 # pylint: disable=too-many-public-methods,too-many-instance-attributes
 class DbSync:
     def __init__(self, connection_config, stream_schema_message=None):
@@ -348,7 +352,7 @@ class DbSync:
         flatten = flatten_record(record, self.flatten_schema, max_level=self.data_flattening_max_level)
         return ','.join(
             [
-                json.dumps(flatten[name], ensure_ascii=False)
+                csv_quote(flatten[name])
                 if name in flatten and (flatten[name] == 0 or flatten[name]) else ''
                 for name in self.flatten_schema
             ]


### PR DESCRIPTION
## Problem

Currently we're using `json.dumps` to quote/escape each column of our CSV rows. However, `json.dumps` escapes characters beyond just the double-quote and backslash characters that will not get unescaped when postgres processes the CSV data. In particular the current method will cause the backspace character (\b), form feed (\f), line feed (\n), carriage return (\r), and tab (\t) to be escaped in the extracted payload mistakenly.

## Proposed changes

Uses a simpler escaping mechanism that only escapes the double-quote character and backslash literals. This appears to be what postgres is expecting; see https://www.postgresql.org/docs/8.0/sql-copy.html.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions